### PR TITLE
feat: codemirror6 markdown editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
 			"name": "lactose",
 			"version": "0.0.1",
 			"dependencies": {
+				"@codemirror/lang-markdown": "^6.1.0",
 				"@milkdown/core": "^7.1.1",
 				"@milkdown/preset-commonmark": "^7.1.1",
-				"@milkdown/preset-gfm": "^7.1.1"
+				"@milkdown/preset-gfm": "^7.1.1",
+				"svelte-codemirror-editor": "^1.1.0"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^2.0.0",
@@ -27,6 +29,138 @@
 				"tslib": "^2.4.1",
 				"typescript": "^5.0.0",
 				"vite": "^4.2.0"
+			}
+		},
+		"node_modules/@codemirror/autocomplete": {
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz",
+			"integrity": "sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.6.0",
+				"@lezer/common": "^1.0.0"
+			},
+			"peerDependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/commands": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.2.tgz",
+			"integrity": "sha512-s9lPVW7TxXrI/7voZ+HmD/yiAlwAYn9PH5SUVSUhsxXHhv4yl5eZ3KLntSoTynfdgVYM0oIpccQEWRBQgmNZyw==",
+			"peer": true,
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.2.0",
+				"@codemirror/view": "^6.0.0",
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/lang-css": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.1.1.tgz",
+			"integrity": "sha512-P6jdNEHyRcqqDgbvHYyC9Wxkek0rnG3a9aVSRi4a7WrjPbQtBTaOmvYpXmm13zZMAatO4Oqpac+0QZs7sy+LnQ==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.0.0",
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@lezer/css": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/lang-html": {
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.3.tgz",
+			"integrity": "sha512-VKzQXEC8nL69Jg2hvAFPBwOdZNvL8tMFOrdFwWpU+wc6a6KEkndJ/19R5xSaglNX6v2bttm8uIEFYxdQDcIZVQ==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.0.0",
+				"@codemirror/lang-css": "^6.0.0",
+				"@codemirror/lang-javascript": "^6.0.0",
+				"@codemirror/language": "^6.4.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.2.2",
+				"@lezer/common": "^1.0.0",
+				"@lezer/css": "^1.1.0",
+				"@lezer/html": "^1.3.0"
+			}
+		},
+		"node_modules/@codemirror/lang-javascript": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.4.tgz",
+			"integrity": "sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.0.0",
+				"@codemirror/language": "^6.6.0",
+				"@codemirror/lint": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"@lezer/common": "^1.0.0",
+				"@lezer/javascript": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/lang-markdown": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.1.0.tgz",
+			"integrity": "sha512-HQDJg1Js19fPKKsI3Rp1X0J6mxyrRy2NX6+Evh0+/jGm6IZHL5ygMGKBYNWKXodoDQFvgdofNRG33gWOwV59Ag==",
+			"dependencies": {
+				"@codemirror/lang-html": "^6.0.0",
+				"@codemirror/language": "^6.3.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"@lezer/common": "^1.0.0",
+				"@lezer/markdown": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/language": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.6.0.tgz",
+			"integrity": "sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"@lezer/common": "^1.0.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"node_modules/@codemirror/lint": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.0.tgz",
+			"integrity": "sha512-KVCECmR2fFeYBr1ZXDVue7x3q5PMI0PzcIbA+zKufnkniMBo1325t0h1jM85AKp8l3tj67LRxVpZfgDxEXlQkg==",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/search": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.3.0.tgz",
+			"integrity": "sha512-rBhZxzT34CarfhgCZGhaLBScABDN3iqJxixzNuINp9lrb3lzm0nTpR77G1VrxGO3HOGK7j62jcJftQM7eCOIuw==",
+			"peer": true,
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.0.tgz",
+			"integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.9.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.3.tgz",
+			"integrity": "sha512-BJ5mvEIhFM+SrNwc5X8pLIvMM9ffjkviVbxpg84Xk2OE8ZyKaEbId8kX+nAYEEso7+qnbwsXe1bkAHsasebMow==",
+			"dependencies": {
+				"@codemirror/state": "^6.1.4",
+				"style-mod": "^4.0.0",
+				"w3c-keyname": "^2.2.4"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -493,6 +627,64 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
+			}
+		},
+		"node_modules/@lezer/common": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.2.tgz",
+			"integrity": "sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng=="
+		},
+		"node_modules/@lezer/css": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.1.tgz",
+			"integrity": "sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==",
+			"dependencies": {
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0"
+			}
+		},
+		"node_modules/@lezer/highlight": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.4.tgz",
+			"integrity": "sha512-IECkFmw2l7sFcYXrV8iT9GeY4W0fU4CxX0WMwhmhMIVjoDdD1Hr6q3G2NqVtLg/yVe5n7i4menG3tJ2r4eCrPQ==",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@lezer/html": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.4.tgz",
+			"integrity": "sha512-HdJYMVZcT4YsMo7lW3ipL4NoyS2T67kMPuSVS5TgLGqmaCjEU/D6xv7zsa1ktvTK5lwk7zzF1e3eU6gBZIPm5g==",
+			"dependencies": {
+				"@lezer/common": "^1.0.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0"
+			}
+		},
+		"node_modules/@lezer/javascript": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.1.tgz",
+			"integrity": "sha512-Hqx36DJeYhKtdpc7wBYPR0XF56ZzIp0IkMO/zNNj80xcaFOV4Oj/P7TQc/8k2TxNhzl7tV5tXS8ZOCPbT4L3nA==",
+			"dependencies": {
+				"@lezer/highlight": "^1.1.3",
+				"@lezer/lr": "^1.3.0"
+			}
+		},
+		"node_modules/@lezer/lr": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.3.tgz",
+			"integrity": "sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@lezer/markdown": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.0.2.tgz",
+			"integrity": "sha512-8CY0OoZ6V5EzPjSPeJ4KLVbtXdLBd8V6sRCooN5kHnO28ytreEGTyrtU/zUwo/XLRzGr/e1g44KlzKi3yWGB5A==",
+			"dependencies": {
+				"@lezer/common": "^1.0.0",
+				"@lezer/highlight": "^1.0.0"
 			}
 		},
 		"node_modules/@milkdown/core": {
@@ -1248,6 +1440,21 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/codemirror": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+			"integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+			"peer": true,
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.0.0",
+				"@codemirror/commands": "^6.0.0",
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/lint": "^6.0.0",
+				"@codemirror/search": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1280,6 +1487,11 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/crelt": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
+			"integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -3787,6 +3999,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/style-mod": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.2.tgz",
+			"integrity": "sha512-C4myMmRTO8iaC5Gg+N1ftK2WT4eXUTMAa+HEFPPrfVeO/NtqLTtAmV1HbqnuGtLwCek44Ra76fdGUkSqjiMPcQ=="
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3853,6 +4070,14 @@
 			},
 			"engines": {
 				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/svelte-codemirror-editor": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/svelte-codemirror-editor/-/svelte-codemirror-editor-1.1.0.tgz",
+			"integrity": "sha512-wFdMIsZds5qzn3x2NbFUxDVU6Cn3rwFdq0035ypaFVgzTjJ90bnPm6IbrFA4OJz1ngIyfbIuPAPDjm7rJIr0gg==",
+			"peerDependencies": {
+				"codemirror": "^6.0.0"
 			}
 		},
 		"node_modules/svelte-hmr": {
@@ -4251,8 +4476,7 @@
 		"node_modules/w3c-keyname": {
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
-			"integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==",
-			"peer": true
+			"integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg=="
 		},
 		"node_modules/which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@codemirror/lang-markdown": "^6.1.0",
 		"@milkdown/core": "^7.1.1",
 		"@milkdown/preset-commonmark": "^7.1.1",
-		"@milkdown/preset-gfm": "^7.1.1"
+		"@milkdown/preset-gfm": "^7.1.1",
+		"svelte-codemirror-editor": "^1.1.0"
 	}
 }

--- a/src/lib/components/CodeMirror.svelte
+++ b/src/lib/components/CodeMirror.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import CodeMirror from 'svelte-codemirror-editor';
+	import { markdown } from '@codemirror/lang-markdown';
+
+	let value = '';
+</script>
+
+<CodeMirror
+	bind:value
+	lang={markdown()}
+	styles={{
+		'&': {
+			width: '500px',
+			maxWidth: '100%',
+			height: '50rem'
+		}
+	}}
+/>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 	import Milkdown from '$lib/components/Milkdown.svelte';
+	import CodeMirror from '$lib/components/CodeMirror.svelte';
 </script>
 
-<Milkdown />
+<div>
+	<Milkdown />
+	<CodeMirror />
+</div>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,7 +6,9 @@ const config = {
 	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
 	// for more information about preprocessors
 	preprocess: vitePreprocess(),
-
+	optimizeDeps: {
+        exclude: ["codemirror", "@codemirror/language-markdown" /* ... */],
+    },
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.


### PR DESCRIPTION
[Linear issue](https://linear.app/syntaxbullet/issue/PER-17/research-how-much-of-a-problem-it-would-be-to-intergrate-monaco-editor)
Adds a codemirror 6 powered markdown editor that will serve as the code preview for lactose, keep in mind this does not include any autocomplete functionality or similar plugins.